### PR TITLE
Autofix: [mentions] Undo does not work if multiple corrections

### DIFF
--- a/client/src/utils/works.jsx
+++ b/client/src/utils/works.jsx
@@ -124,20 +124,48 @@ const range = (startYear, endYear = new Date().getFullYear()) => {
   return (start === end) ? [start] : [start, ...range(start + 1, end)];
 };
 
-const renderButtons = (selected, fn) => Object.values(status).map((st) => (
+const undoCorrections = (selected, fn) => {
+  selected.forEach((item) => {
+    if (item.previousStatus) {
+      fn([item], item.previousStatus);
+      delete item.previousStatus;
+    }
+  });
+};
+
+const renderButtons = (selected, fn) => [
+  ...Object.values(status).map((st) => (
+    <Button
+      className="fr-mb-1w fr-pl-1w button"
+      disabled={!selected.length}
+      key={st.id}
+      onClick={() => {
+        selected.forEach((item) => {
+          item.previousStatus = item.status;
+        });
+        fn(selected, st.id);
+      }}
+      size="lg"
+      style={{ display: 'block', width: '100%', textAlign: 'left' }}
+      color="blue-ecume"
+    >
+      <i className={`${st.buttonIcon} fr-mr-2w`} style={{ color: st.iconColor }} />
+      {st.buttonLabel}
+    </Button>
+  )),
   <Button
     className="fr-mb-1w fr-pl-1w button"
-    disabled={!selected.length}
-    key={st.id}
-    onClick={() => fn(selected, st.id)}
+    disabled={!selected.some((item) => item.previousStatus)}
+    key="undo"
+    onClick={() => undoCorrections(selected, fn)}
     size="lg"
     style={{ display: 'block', width: '100%', textAlign: 'left' }}
     color="blue-ecume"
   >
-    <i className={`${st.buttonIcon} fr-mr-2w`} style={{ color: st.iconColor }} />
-    {st.buttonLabel}
+    <i className="ri-arrow-go-back-line fr-mr-2w" style={{ color: '#000091' }} />
+    Undo
   </Button>
-));
+];
 
 const renderButtonDataset = (selected, fn, label, icon) => (
   <Button


### PR DESCRIPTION
I've identified the issue in the undo functionality for corrections. The problem occurs because the undo operation is not properly tracking the state of individual corrections. To fix this, I've modified the `renderButtons` function in `client/src/utils/works.jsx` to include an undo button that properly manages the state of corrections.

Here's a summary of the changes:

1. Added an 'undo' button to the `renderButtons` function.
2. Implemented a new `undoCorrections` function to handle the undo operation.
3. Modified the button rendering to include the undo functionality.
4. Updated the state management to properly track individual corrections.

These changes should resolve the issue where undoing multiple corrections results in unexpected behavior. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission